### PR TITLE
fix: handle x-ratelimit-reset for secondary rate limit

### DIFF
--- a/github_ratelimit/api.go
+++ b/github_ratelimit/api.go
@@ -1,0 +1,7 @@
+package github_ratelimit
+
+const (
+	HeaderRetryAfter          = "retry-after"
+	HeaderXRateLimitReset     = "x-ratelimit-reset"
+	HeaderXRateLimitRemaining = "x-ratelimit-remaining"
+)

--- a/github_ratelimit/github_ratelimit_test/ratelimit_injecter.go
+++ b/github_ratelimit/github_ratelimit_test/ratelimit_injecter.go
@@ -4,27 +4,17 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 )
 
-type SecondaryRateLimitInjecter struct {
-	base          http.RoundTripper
-	options       *SecondaryRateLimitInjecterOptions
-	blockUntil    time.Time
-	lock          sync.Mutex
-	AbuseAttempts int
-}
-
-const (
-	RateLimitInjecterEvery    = "SECONDARY_RATE_LIMIT_INJECTER_EVERY"
-	RateLimitInjecterDuration = "SECONDARY_RATE_LIMIT_INJECTER_DURATION"
-)
-
 type SecondaryRateLimitInjecterOptions struct {
-	Every time.Duration
-	Sleep time.Duration
+	Every               time.Duration
+	Sleep               time.Duration
+	UseXRateLimit       bool
+	UsePrimaryRateLimit bool
 }
 
 func NewRateLimitInjecter(base http.RoundTripper, options *SecondaryRateLimitInjecterOptions) (http.RoundTripper, error) {
@@ -40,6 +30,28 @@ func NewRateLimitInjecter(base http.RoundTripper, options *SecondaryRateLimitInj
 		options: options,
 	}
 	return injecter, nil
+}
+
+func (r *SecondaryRateLimitInjecterOptions) IsNoop() bool {
+	return r.Every == 0 || r.Sleep == 0
+}
+
+func (r *SecondaryRateLimitInjecterOptions) Validate() error {
+	if r.Every < 0 {
+		return fmt.Errorf("injecter expects a positive trigger interval")
+	}
+	if r.Sleep < 0 {
+		return fmt.Errorf("injecter expects a positive sleep interval")
+	}
+	return nil
+}
+
+type SecondaryRateLimitInjecter struct {
+	base          http.RoundTripper
+	options       *SecondaryRateLimitInjecterOptions
+	blockUntil    time.Time
+	lock          sync.Mutex
+	AbuseAttempts int
 }
 
 func (t *SecondaryRateLimitInjecter) RoundTrip(request *http.Request) (*http.Response, error) {
@@ -60,7 +72,7 @@ func (t *SecondaryRateLimitInjecter) RoundTrip(request *http.Request) (*http.Res
 	// on-going rate limit
 	if t.blockUntil.After(now) {
 		t.AbuseAttempts++
-		return t.toRetryResponse(resp), nil
+		return t.inject(resp), nil
 	}
 
 	nextStart := t.NextSleepStart()
@@ -68,25 +80,12 @@ func (t *SecondaryRateLimitInjecter) RoundTrip(request *http.Request) (*http.Res
 	// start a rate limit period
 	if !now.Before(nextStart) {
 		t.blockUntil = nextStart.Add(t.options.Sleep)
-		return t.toRetryResponse(resp), nil
+		return t.inject(resp), nil
 	}
 
 	return resp, nil
 }
 
-func (r *SecondaryRateLimitInjecterOptions) IsNoop() bool {
-	return r.Every == 0 || r.Sleep == 0
-}
-
-func (r *SecondaryRateLimitInjecterOptions) Validate() error {
-	if r.Every < 0 {
-		return fmt.Errorf("injecter expects a positive trigger interval")
-	}
-	if r.Sleep < 0 {
-		return fmt.Errorf("injecter expects a positive sleep interval")
-	}
-	return nil
-}
 func (r *SecondaryRateLimitInjecter) CurrentSleepEnd() time.Time {
 	return r.blockUntil
 }
@@ -95,14 +94,50 @@ func (r *SecondaryRateLimitInjecter) NextSleepStart() time.Time {
 	return r.blockUntil.Add(r.options.Every)
 }
 
+var secondaryRateLimitBody = `{
+	"message": "You have exceeded a secondary rate limit and have been temporarily blocked from content creation. Please retry your request again later.",
+	"documentation_url": "https://docs.github.com/rest/overview/resources-in-the-rest-api#secondary-rate-limits"
+}`
+
+func (t *SecondaryRateLimitInjecter) inject(resp *http.Response) *http.Response {
+	if t.options.UsePrimaryRateLimit {
+		return t.toPrimaryRateLimitResponse(resp)
+	} else {
+		resp.StatusCode = http.StatusForbidden
+		resp.Body = io.NopCloser(strings.NewReader(secondaryRateLimitBody))
+		if t.options.UseXRateLimit {
+			return t.toXRateLimitResponse(resp)
+		} else {
+			return t.toRetryResponse(resp)
+		}
+	}
+}
+
 func (t *SecondaryRateLimitInjecter) toRetryResponse(resp *http.Response) *http.Response {
-	resp.StatusCode = http.StatusForbidden
+	secondsToBlock := t.getTimeToBlock()
+	httpHeaderSetIntValue(resp, "retry-after", int(secondsToBlock.Seconds()))
+	return resp
+}
+
+func (t *SecondaryRateLimitInjecter) toXRateLimitResponse(resp *http.Response) *http.Response {
+	endOfBlock := time.Now().Add(t.getTimeToBlock())
+	httpHeaderSetIntValue(resp, "x-ratelimit-reset", int(endOfBlock.Unix()))
+	return resp
+}
+
+func (t *SecondaryRateLimitInjecter) toPrimaryRateLimitResponse(resp *http.Response) *http.Response {
+	httpHeaderSetIntValue(resp, "x-ratelimit-remaining", 0)
+	return t.toXRateLimitResponse(resp)
+}
+
+func (t *SecondaryRateLimitInjecter) getTimeToBlock() time.Duration {
 	timeUntil := time.Until(t.blockUntil)
 	if timeUntil.Nanoseconds()%int64(time.Second) > 0 {
 		timeUntil += time.Second
 	}
-	resp.Header.Set("Retry-After", fmt.Sprintf("%v", int(timeUntil.Seconds())))
-	doc_url := "https://docs.github.com/en/rest/guides/best-practices-for-integrators?apiVersion=2022-11-28#secondary-rate-limits"
-	resp.Body = io.NopCloser(strings.NewReader(`{"documentation_url":"` + doc_url + `"}`))
-	return resp
+	return timeUntil
+}
+
+func httpHeaderSetIntValue(resp *http.Response, key string, value int) {
+	resp.Header.Set(key, strconv.Itoa(value))
 }

--- a/github_ratelimit/github_ratelimit_test/ratelimit_injecter.go
+++ b/github_ratelimit/github_ratelimit_test/ratelimit_injecter.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/gofri/go-github-ratelimit/github_ratelimit"
 )
 
 type SecondaryRateLimitInjecterOptions struct {
@@ -115,18 +117,18 @@ func (t *SecondaryRateLimitInjecter) inject(resp *http.Response) *http.Response 
 
 func (t *SecondaryRateLimitInjecter) toRetryResponse(resp *http.Response) *http.Response {
 	secondsToBlock := t.getTimeToBlock()
-	httpHeaderSetIntValue(resp, "retry-after", int(secondsToBlock.Seconds()))
+	httpHeaderSetIntValue(resp, github_ratelimit.HeaderRetryAfter, int(secondsToBlock.Seconds()))
 	return resp
 }
 
 func (t *SecondaryRateLimitInjecter) toXRateLimitResponse(resp *http.Response) *http.Response {
 	endOfBlock := time.Now().Add(t.getTimeToBlock())
-	httpHeaderSetIntValue(resp, "x-ratelimit-reset", int(endOfBlock.Unix()))
+	httpHeaderSetIntValue(resp, github_ratelimit.HeaderXRateLimitReset, int(endOfBlock.Unix()))
 	return resp
 }
 
 func (t *SecondaryRateLimitInjecter) toPrimaryRateLimitResponse(resp *http.Response) *http.Response {
-	httpHeaderSetIntValue(resp, "x-ratelimit-remaining", 0)
+	httpHeaderSetIntValue(resp, github_ratelimit.HeaderXRateLimitRemaining, 0)
 	return t.toXRateLimitResponse(resp)
 }
 

--- a/github_ratelimit/ratelimit.go
+++ b/github_ratelimit/ratelimit.go
@@ -9,7 +9,7 @@ import (
 )
 
 type SecondaryRateLimitWaiter struct {
-	base       http.RoundTripper
+	Base       http.RoundTripper
 	sleepUntil *time.Time
 	lock       sync.RWMutex
 
@@ -31,7 +31,7 @@ func NewRateLimitWaiter(base http.RoundTripper, opts ...Option) (*SecondaryRateL
 	}
 
 	waiter := SecondaryRateLimitWaiter{
-		base: base,
+		Base: base,
 	}
 	applyOptions(&waiter, opts...)
 
@@ -60,7 +60,7 @@ func NewRateLimitWaiterClient(base http.RoundTripper, opts ...Option) (*http.Cli
 func (t *SecondaryRateLimitWaiter) RoundTrip(request *http.Request) (*http.Response, error) {
 	t.waitForRateLimit()
 
-	resp, err := t.base.RoundTrip(request)
+	resp, err := t.Base.RoundTrip(request)
 	if err != nil {
 		return resp, err
 	}

--- a/github_ratelimit/ratelimit.go
+++ b/github_ratelimit/ratelimit.go
@@ -183,12 +183,12 @@ func parseRetryAfter(header http.Header) *time.Time {
 // to avoid handling primary rate limits (which are categorized),
 // we only handle x-ratelimit-reset in case the primary rate limit is not reached.
 func parseXRateLimitReset(header http.Header) *time.Time {
-	if remaining, ok := httpHeaderIntValue(header, "x-ratelimit-remaining"); ok && remaining == 0 {
+	if remaining, ok := httpHeaderIntValue(header, HeaderXRateLimitRemaining); ok && remaining == 0 {
 		// this is a primary rate limit; ignore it
 		return nil
 	}
 
-	secondsSinceEpoch, ok := httpHeaderIntValue(header, "x-ratelimit-reset")
+	secondsSinceEpoch, ok := httpHeaderIntValue(header, HeaderXRateLimitReset)
 	if !ok || secondsSinceEpoch <= 0 {
 		return nil
 	}

--- a/github_ratelimit/ratelimit.go
+++ b/github_ratelimit/ratelimit.go
@@ -200,11 +200,11 @@ func parseXRateLimitReset(header http.Header) *time.Time {
 }
 
 func httpHeaderIntValue(header http.Header, key string) (int64, bool) {
-	val, ok := header[http.CanonicalHeaderKey(key)]
-	if !ok || len(val) == 0 {
+	val := header.Get(key)
+	if val == "" {
 		return 0, false
 	}
-	asInt, err := strconv.ParseInt(val[0], 10, 64)
+	asInt, err := strconv.ParseInt(val, 10, 64)
 	if err != nil {
 		return 0, false
 	}

--- a/github_ratelimit/ratelimit_test.go
+++ b/github_ratelimit/ratelimit_test.go
@@ -156,7 +156,7 @@ func TestSingleSleepLimit(t *testing.T) {
 	if got, want := resp.Header.Get("Retry-After"), fmt.Sprintf("%v", sleep.Seconds()); got != want {
 		t.Fatal(got, want)
 	}
-	// try again - make sure that triggering the callback doesn't cause it to sleep next time
+	// try again - make sure that triggering the callback does not cause it to sleep next time
 	tBefore := time.Now()
 	_, err = c.Get("/")
 	if err != nil {
@@ -217,7 +217,7 @@ func TestTotalSleepLimit(t *testing.T) {
 	if got, want := resp.Header.Get("Retry-After"), fmt.Sprintf("%v", sleep.Seconds()); got != want {
 		t.Fatal(got, want)
 	}
-	// try again - make sure that triggering the callback doesn't cause it to sleep next time
+	// try again - make sure that triggering the callback does not cause it to sleep next time
 	tBefore := time.Now()
 	_, err = c.Get("/")
 	if err != nil {


### PR DESCRIPTION
fixes #9
while at it, this PR also:
- fixes typos in documentation
- exports header keys as consts
- makes Base (the base roundtripper) public
- moves the testing into the github_ratelimit_test package -- making them clear close-box testing