### PR TITLE
Make the Secondary Rate limit check more resiliant

### DIFF
--- a/github_ratelimit/detect.go
+++ b/github_ratelimit/detect.go
@@ -19,7 +19,7 @@ const (
 )
 
 func (s SecondaryRateLimitBody) IsSecondaryRateLimit() bool {
-	return strings.Contains(s.Message, SecondaryRateLimitMessage) && s.DocumentURL == SecondaryRateLimitDocumentationURL
+	return strings.HasPrefix(s.Message, SecondaryRateLimitMessage) && s.DocumentURL == SecondaryRateLimitDocumentationURL
 }
 
 // isSecondaryRateLimit checks whether the response is a legitimate secondary rate limit.


### PR DESCRIPTION
Just makes the check against SecondaryRate limit a bit more resilient to Github changing things.  

There may be a better way than this just how I got it working for my team. 