### PR TITLE
Check documentation url suffix

### DIFF
--- a/github_ratelimit/detect.go
+++ b/github_ratelimit/detect.go
@@ -14,12 +14,12 @@ type SecondaryRateLimitBody struct {
 }
 
 const (
-	SecondaryRateLimitMessage          = `You have exceeded a secondary rate limit`
-	SecondaryRateLimitDocumentationURL = `https://docs.github.com/rest/overview/resources-in-the-rest-api#secondary-rate-limits`
+	SecondaryRateLimitMessage           = `You have exceeded a secondary rate limit`
+	SecondaryRateLimitDocumentationPath = `/rest/overview/resources-in-the-rest-api#secondary-rate-limits`
 )
 
 func (s SecondaryRateLimitBody) IsSecondaryRateLimit() bool {
-	return strings.HasPrefix(s.Message, SecondaryRateLimitMessage) && s.DocumentURL == SecondaryRateLimitDocumentationURL
+	return strings.HasPrefix(s.Message, SecondaryRateLimitMessage) && strings.HasSuffix(s.DocumentURL, SecondaryRateLimitDocumentationPath)
 }
 
 // isSecondaryRateLimit checks whether the response is a legitimate secondary rate limit.

--- a/github_ratelimit/detect.go
+++ b/github_ratelimit/detect.go
@@ -18,6 +18,10 @@ const (
 	SecondaryRateLimitDocumentationPath = `/rest/overview/resources-in-the-rest-api#secondary-rate-limits`
 )
 
+// IsSecondaryRateLimit checks whether the response is a legitimate secondary rate limit.
+// It checks the prefix of the message and the suffix of the documentation URL in the response body in case
+// the message or documentation URL is modified in the future.
+// https://docs.github.com/en/rest/overview/resources-in-the-rest-api#secondary-rate-limits
 func (s SecondaryRateLimitBody) IsSecondaryRateLimit() bool {
 	return strings.HasPrefix(s.Message, SecondaryRateLimitMessage) && strings.HasSuffix(s.DocumentURL, SecondaryRateLimitDocumentationPath)
 }

--- a/github_ratelimit/github_ratelimit_test/ratelimit_injecter.go
+++ b/github_ratelimit/github_ratelimit_test/ratelimit_injecter.go
@@ -17,6 +17,11 @@ const (
 	InvalidBodyContent = `{"message": "not as expected"}`
 )
 
+const (
+	SecondaryRateLimitMessage          = `You have exceeded a secondary rate limit. Please wait a few minutes before you try again.`
+	SecondaryRateLimitDocumentationURL = `https://docs.github.com/rest/overview/resources-in-the-rest-api#secondary-rate-limits`
+)
+
 type SecondaryRateLimitInjecterOptions struct {
 	Every               time.Duration
 	Sleep               time.Duration
@@ -104,8 +109,8 @@ func (r *SecondaryRateLimitInjecter) NextSleepStart() time.Time {
 
 func getSecondaryRateLimitBody() (io.ReadCloser, error) {
 	body := github_ratelimit.SecondaryRateLimitBody{
-		Message:     github_ratelimit.SecondaryRateLimitMessage,
-		DocumentURL: github_ratelimit.SecondaryRateLimitDocumentationURL,
+		Message:     SecondaryRateLimitMessage,
+		DocumentURL: SecondaryRateLimitDocumentationURL,
 	}
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {

--- a/github_ratelimit/github_ratelimit_test/ratelimit_injecter.go
+++ b/github_ratelimit/github_ratelimit_test/ratelimit_injecter.go
@@ -18,16 +18,18 @@ const (
 )
 
 const (
-	SecondaryRateLimitMessage          = `You have exceeded a secondary rate limit. Please wait a few minutes before you try again.`
-	SecondaryRateLimitDocumentationURL = `https://docs.github.com/rest/overview/resources-in-the-rest-api#secondary-rate-limits`
+	SecondaryRateLimitMessage                   = `You have exceeded a secondary rate limit. Please wait a few minutes before you try again.`
+	SecondaryRateLimitDocumentationURL          = `https://docs.github.com/rest/overview/resources-in-the-rest-api#secondary-rate-limits`
+	SecondaryRateLimitAlternateDocumentationURL = `https://docs.github.com/free-pro-team@latest/rest/overview/resources-in-the-rest-api#secondary-rate-limits`
 )
 
 type SecondaryRateLimitInjecterOptions struct {
-	Every               time.Duration
-	Sleep               time.Duration
-	UseXRateLimit       bool
-	UsePrimaryRateLimit bool
-	InvalidBody         bool
+	Every                        time.Duration
+	Sleep                        time.Duration
+	InvalidBody                  bool
+	UseXRateLimit                bool
+	UsePrimaryRateLimit          bool
+	UseAlternateDocumentationURL bool
 }
 
 func NewRateLimitInjecter(base http.RoundTripper, options *SecondaryRateLimitInjecterOptions) (http.RoundTripper, error) {
@@ -107,10 +109,16 @@ func (r *SecondaryRateLimitInjecter) NextSleepStart() time.Time {
 	return r.blockUntil.Add(r.options.Every)
 }
 
-func getSecondaryRateLimitBody() (io.ReadCloser, error) {
+func getSecondaryRateLimitBody(useAlternatateDocumentationURL bool) (io.ReadCloser, error) {
+	documentURL := SecondaryRateLimitDocumentationURL
+
+	if useAlternatateDocumentationURL {
+		documentURL = SecondaryRateLimitAlternateDocumentationURL
+	}
+
 	body := github_ratelimit.SecondaryRateLimitBody{
 		Message:     SecondaryRateLimitMessage,
-		DocumentURL: SecondaryRateLimitDocumentationURL,
+		DocumentURL: documentURL,
 	}
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
@@ -124,7 +132,7 @@ func (t *SecondaryRateLimitInjecter) inject(resp *http.Response) (*http.Response
 	if t.options.UsePrimaryRateLimit {
 		return t.toPrimaryRateLimitResponse(resp), nil
 	} else {
-		body, err := getSecondaryRateLimitBody()
+		body, err := getSecondaryRateLimitBody(t.options.UseAlternateDocumentationURL)
 		if err != nil {
 			return nil, err
 		}

--- a/github_ratelimit/github_ratelimit_test/ratelimit_test.go
+++ b/github_ratelimit/github_ratelimit_test/ratelimit_test.go
@@ -395,7 +395,7 @@ func TestHTTPForbiddenIgnored(t *testing.T) {
 	_, _ = c.Get("/")
 	waitForNextSleep(i)
 
-	// attempt during rate limit (using invalid body, so the injction is of HTTP Foribdden)
+	// attempt during rate limit (using invalid body, so the injection is of HTTP Forbidden)
 	resp, err := c.Get("/")
 	if err != nil {
 		t.Fatal(err)
@@ -404,9 +404,9 @@ func TestHTTPForbiddenIgnored(t *testing.T) {
 		t.Fatal(slept)
 	}
 
-	if invaidBody, err := IsInvalidBody(resp); err != nil {
+	if invalidBody, err := IsInvalidBody(resp); err != nil {
 		t.Fatal(err)
-	} else if !invaidBody {
+	} else if !invalidBody {
 		t.Fatalf("expected invalid body")
 	}
 }


### PR DESCRIPTION
Apparently GitHub changed the `documentation_url` value, thus not detecting the rate limit.

Here's the response I'm getting when hitting a secondary rate limit:

```json
{
  "documentation_url": "https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#secondary-rate-limits",
  "message": "You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID [REQUEST_ID]."
}
```

Instead of comparing the exact same documentation url, we can instead check for the url suffix, which has been the same across changes, this to fix and future-proof any existing url changes in the future as well.

This is similar to the case of the message, when we check for the prefix.