### PR TITLE
Fix documentation URL check

### DIFF
--- a/github_ratelimit/detect.go
+++ b/github_ratelimit/detect.go
@@ -14,8 +14,8 @@ type SecondaryRateLimitBody struct {
 }
 
 const (
-	SecondaryRateLimitMessage           = `You have exceeded a secondary rate limit`
-	SecondaryRateLimitDocumentationPath = `/rest/overview/rate-limits-for-the-rest-api#about-secondary-rate-limits`
+	SecondaryRateLimitMessage                 = `You have exceeded a secondary rate limit`
+	SecondaryRateLimitDocumentationPathSuffix = `secondary-rate-limits`
 )
 
 // IsSecondaryRateLimit checks whether the response is a legitimate secondary rate limit.
@@ -23,7 +23,7 @@ const (
 // the message or documentation URL is modified in the future.
 // https://docs.github.com/en/rest/overview/rate-limits-for-the-rest-api#about-secondary-rate-limits
 func (s SecondaryRateLimitBody) IsSecondaryRateLimit() bool {
-	return strings.HasPrefix(s.Message, SecondaryRateLimitMessage) || strings.HasSuffix(s.DocumentURL, SecondaryRateLimitDocumentationPath)
+	return strings.HasPrefix(s.Message, SecondaryRateLimitMessage) || strings.HasSuffix(s.DocumentURL, SecondaryRateLimitDocumentationPathSuffix)
 }
 
 // isSecondaryRateLimit checks whether the response is a legitimate secondary rate limit.

--- a/github_ratelimit/detect.go
+++ b/github_ratelimit/detect.go
@@ -15,13 +15,13 @@ type SecondaryRateLimitBody struct {
 
 const (
 	SecondaryRateLimitMessage           = `You have exceeded a secondary rate limit`
-	SecondaryRateLimitDocumentationPath = `/rest/overview/resources-in-the-rest-api#secondary-rate-limits`
+	SecondaryRateLimitDocumentationPath = `/rest/overview/rate-limits-for-the-rest-api#about-secondary-rate-limits`
 )
 
 // IsSecondaryRateLimit checks whether the response is a legitimate secondary rate limit.
 // It checks the prefix of the message and the suffix of the documentation URL in the response body in case
 // the message or documentation URL is modified in the future.
-// https://docs.github.com/en/rest/overview/resources-in-the-rest-api#secondary-rate-limits
+// https://docs.github.com/en/rest/overview/rate-limits-for-the-rest-api#about-secondary-rate-limits
 func (s SecondaryRateLimitBody) IsSecondaryRateLimit() bool {
 	return strings.HasPrefix(s.Message, SecondaryRateLimitMessage) && strings.HasSuffix(s.DocumentURL, SecondaryRateLimitDocumentationPath)
 }

--- a/github_ratelimit/detect.go
+++ b/github_ratelimit/detect.go
@@ -23,7 +23,7 @@ const (
 // the message or documentation URL is modified in the future.
 // https://docs.github.com/en/rest/overview/rate-limits-for-the-rest-api#about-secondary-rate-limits
 func (s SecondaryRateLimitBody) IsSecondaryRateLimit() bool {
-	return strings.HasPrefix(s.Message, SecondaryRateLimitMessage) && strings.HasSuffix(s.DocumentURL, SecondaryRateLimitDocumentationPath)
+	return strings.HasPrefix(s.Message, SecondaryRateLimitMessage) || strings.HasSuffix(s.DocumentURL, SecondaryRateLimitDocumentationPath)
 }
 
 // isSecondaryRateLimit checks whether the response is a legitimate secondary rate limit.


### PR DESCRIPTION
First of all, thanks for creating and maintaining this library!

Apparently, without warning, GitHub changed error message regarding secondary rate limit again.

From: 
```
https://docs.github.com/free-pro-team@latest/rest/overview/resources-in-the-rest-api#secondary-rate-limits
```
To:
```
https://docs.github.com/en/free-pro-team@latest/rest/overview/rate-limits-for-the-rest-api#about-secondary-rate-limits
```
 Which is valid action considering the old one is dead (to be precise: no longer includes rate limit section which was extracted to separate page).


This PR:
- replaces the URL suffix with the newest one
- fixes the [detection logic](https://github.com/gofri/go-github-ratelimit/blob/main/github_ratelimit/detect.go#L26) from `AND` to `OR` - the documentation mentions that it's is performed in case the message or URL changes - which I believe doesn't achieve its goal right now
- modifies tests to cover all three URLs