### PR TITLE
docs: update link to secondary rate limit in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/gofri/go-github-ratelimit)](https://goreportcard.com/report/github.com/gofri/go-github-ratelimit)
 
-Package go-github-ratelimit provides a http.RoundTripper implementation that handles [secondary rate limit](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#secondary-rate-limits) for the GitHub API.  
+Package `go-github-ratelimit` provides an http.RoundTripper implementation that handles [secondary rate limit](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#about-secondary-rate-limits) for the GitHub API.  
 The RoundTripper waits for the secondary rate limit to finish in a blocking mode and then issues/retries requests.
 
-go-github-ratelimit can be used with any HTTP client communicating with GitHub API.    
+`go-github-ratelimit` can be used with any HTTP client communicating with GitHub API.    
 It is meant to complement [go-github](https://github.com/google/go-github), but there is no association between this repository and the go-github repository or Google.  
   
 ## Installation


### PR DESCRIPTION
The link was pointing to general API docs (redirected), whereas now it points to the section about secondary rate limits.

Additional minor improvements in README.md