### PR TITLE
feat: support HTTP status code 429 (Too Many Requests)

### DIFF
--- a/github_ratelimit/detect.go
+++ b/github_ratelimit/detect.go
@@ -34,7 +34,6 @@ func isRateLimitStatus(statusCode int) bool {
 }
 
 // isSecondaryRateLimit checks whether the response is a legitimate secondary rate limit.
-// it is used to avoid handling primary rate limits and authentic HTTP Forbidden (403) responses.
 func isSecondaryRateLimit(resp *http.Response) bool {
 	if !isRateLimitStatus(resp.StatusCode) {
 		return false
@@ -49,7 +48,7 @@ func isSecondaryRateLimit(resp *http.Response) bool {
 		return false
 	}
 
-	// an authentic HTTP Forbidden (403) response
+	// an authentic HTTP response (not a primary rate limit)
 	defer resp.Body.Close()
 	rawBody, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/github_ratelimit/detect.go
+++ b/github_ratelimit/detect.go
@@ -23,13 +23,20 @@ const (
 // the message or documentation URL is modified in the future.
 // https://docs.github.com/en/rest/overview/rate-limits-for-the-rest-api#about-secondary-rate-limits
 func (s SecondaryRateLimitBody) IsSecondaryRateLimit() bool {
-	return strings.HasPrefix(s.Message, SecondaryRateLimitMessage) || strings.HasSuffix(s.DocumentURL, SecondaryRateLimitDocumentationPathSuffix)
+	return strings.HasPrefix(s.Message, SecondaryRateLimitMessage) ||
+		strings.HasSuffix(s.DocumentURL, SecondaryRateLimitDocumentationPathSuffix)
+}
+
+// isRateLimitStatus checks whether the status code is a rate limit status code.
+// see https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api#exceeding-the-rate-limit
+func isRateLimitStatus(statusCode int) bool {
+	return statusCode == http.StatusForbidden || statusCode == http.StatusTooManyRequests
 }
 
 // isSecondaryRateLimit checks whether the response is a legitimate secondary rate limit.
 // it is used to avoid handling primary rate limits and authentic HTTP Forbidden (403) responses.
 func isSecondaryRateLimit(resp *http.Response) bool {
-	if resp.StatusCode != http.StatusForbidden {
+	if !isRateLimitStatus(resp.StatusCode) {
 		return false
 	}
 

--- a/github_ratelimit/ratelimit.go
+++ b/github_ratelimit/ratelimit.go
@@ -172,6 +172,10 @@ func parseSecondaryLimitTime(resp *http.Response) *time.Time {
 		return sleepUntil
 	}
 
+	// XXX: per GitHub API docs, we should default to a 60 second sleep time in case the header is missing,
+	//		with an exponential backoff mechanism.
+	//		we may want to implement this in the future (with configurable limits),
+	//		but let's avoid it while there are no known cases of missing headers.
 	return nil
 }
 
@@ -223,7 +227,7 @@ func smoothSleepTime(sleepTime time.Duration) time.Duration {
 	if sleepTime.Milliseconds() == 0 {
 		return sleepTime
 	} else {
-		seconds := (sleepTime.Seconds()) + 1
+		seconds := sleepTime.Seconds() + 1
 		return time.Duration(seconds) * time.Second
 	}
 }

--- a/github_ratelimit/ratelimit.go
+++ b/github_ratelimit/ratelimit.go
@@ -172,7 +172,7 @@ func parseSecondaryLimitTime(resp *http.Response) *time.Time {
 		return sleepUntil
 	}
 
-	// XXX: per GitHub API docs, we should default to a 60 second sleep time in case the header is missing,
+	// XXX: per GitHub API docs, we should default to a 60 seconds sleep time in case the header is missing,
 	//		with an exponential backoff mechanism.
 	//		we may want to implement this in the future (with configurable limits),
 	//		but let's avoid it while there are no known cases of missing headers.


### PR DESCRIPTION
As per the updated [GitHub API docs](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#exceeding-the-rate-limit), GitHub may respond with a TooManyRequests (429) response for rate limits now.
Let's support that before it starts popping in practice.