### PR TITLE
retry even if x-ratelimit-remaining header is zero

### DIFF
--- a/github_ratelimit/detect.go
+++ b/github_ratelimit/detect.go
@@ -45,7 +45,7 @@ func isSecondaryRateLimit(resp *http.Response) bool {
 
 	// a primary rate limit
 	if remaining, ok := httpHeaderIntValue(resp.Header, HeaderXRateLimitRemaining); ok && remaining == 0 {
-		return false
+		return true
 	}
 
 	// an authentic HTTP response (not a primary rate limit)


### PR DESCRIPTION
Hello!

Thank you for this library!
I tried to use this library and got error like below.

## test code
part of go.mod
```
...
go 1.21.3

require (
    github.com/gofri/go-github-ratelimit v1.1.0
    github.com/google/go-github/v56 v56.0.0
...
replace github.com/gofri/go-github-ratelimit => ../../../../gofri/go-github-ratelimit/
```
my local replaced go-github-ratelimit is https://github.com/nktks/go-github-ratelimit/commit/1788ec6f48c7f085fd549c71d6742b39930aceb6

part of test script
```
   hc := oauth2.NewClient(ctx, oauth2.StaticTokenSource(
        &oauth2.Token{AccessToken: token},
    ))

    rateLimiter, err := github_ratelimit.NewRateLimitWaiterClient(hc.Transport)
    if err != nil {
        return nil, err
    }
    c := github.NewClient(rateLimiter)
...
```

got error with debug log
```
...
shouldRetry
ok
true
0
not isSecondaryRateLimit
secondaryLimit:<nil>
Error: GET https://api.github.com/search/issues?q=org%3A<org>+repo%3A<repo>+is%3Apr+state%3Aopen+<condition>: 403 You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID <request id>. [rate limit was reset 0s ago]
```
(I snipped some values)

Then I changed the code to retry even though `x-ratelimit-remaining` header value is 0.
And my error was fixed.

Could you please review this?