### PR TITLE
Make sleep interruptible when request context expire.

### DIFF
--- a/github_ratelimit/sleep.go
+++ b/github_ratelimit/sleep.go
@@ -1,0 +1,19 @@
+package github_ratelimit
+
+import (
+	"context"
+	"time"
+)
+
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	select {
+	case <-ctx.Done():
+		if !timer.Stop() {
+			<-timer.C
+		}
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/github_ratelimit/sleep_test.go
+++ b/github_ratelimit/sleep_test.go
@@ -1,0 +1,70 @@
+package github_ratelimit
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_SleepWithContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	start := time.Now()
+	go func() {
+		err := sleepWithContext(ctx, 1*time.Second)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+		wg.Done()
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	wg.Wait()
+	elapsed := time.Since(start)
+	assert.LessOrEqual(t, elapsed, 100*time.Millisecond)
+}
+
+func Test_SleepWithContext(t *testing.T) {
+	ctx := context.Background()
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	start := time.Now()
+	go func() {
+		err := sleepWithContext(ctx, 50*time.Millisecond)
+		assert.NoError(t, err)
+		wg.Done()
+	}()
+
+	wg.Wait()
+	elapsed := time.Since(start)
+	assert.LessOrEqual(t, elapsed, 100*time.Millisecond)
+}
+
+func Test_SleepWithContextTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	start := time.Now()
+	go func() {
+		err := sleepWithContext(ctx, 1*time.Second)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+		wg.Done()
+	}()
+
+	wg.Wait()
+	elapsed := time.Since(start)
+	assert.LessOrEqual(t, elapsed, 100*time.Millisecond)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/gofri/go-github-ratelimit
 
 go 1.19
+
+require github.com/stretchr/testify v1.9.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
When using this library in a CLI tool, I like to connect a context to CTRL-C signal allowing for early interruption. The problem is that with very long second rate limit, you can get the CLI lock in a sleep that can not be interrupted which is not ideal. This PR address that problem by using the context from the request and a timer channel to handle this scenario.

This comes with test for verifying that SleepWithContext behave as expected. I have introduced the use of testify by habit mostly, but the test look nicer with it in my opinion. Let me know if you prefer a different approach for the test.