### PR TITLE
Feature: WithResetOnSuccessfulCall Option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+### Example user template template
+### Example user template
+
+# IntelliJ project files
+.idea
+*.iml
+out
+gen
+### Go template
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+go.work.sum
+
+# env file
+.env
+

--- a/github_ratelimit/github_primary_ratelimit/category.go
+++ b/github_ratelimit/github_primary_ratelimit/category.go
@@ -80,7 +80,8 @@ func GetAllCategories() []ResourceCategory {
 }
 
 func parseRequestCategory(request *http.Request) ResourceCategory {
-	return parseCategory(request.Method, request.URL.RawPath)
+	// RawPath is only populated when there is encoding in the path
+	return parseCategory(request.Method, request.URL.Path)
 }
 
 func parseCategory(method string, path string) ResourceCategory {

--- a/github_ratelimit/github_primary_ratelimit/config.go
+++ b/github_ratelimit/github_primary_ratelimit/config.go
@@ -6,8 +6,9 @@ import "context"
 // It is used internally and generated from the options.
 // It holds the state of the rate limiter in order to enable state sharing.
 type Config struct {
-	state       *RateLimitState
-	bypassLimit bool
+	state          *RateLimitState
+	bypassLimit    bool
+	resetOnSuccess bool
 
 	// callbacks
 	onLimitReached     OnLimitReached

--- a/github_ratelimit/github_primary_ratelimit/options.go
+++ b/github_ratelimit/github_primary_ratelimit/options.go
@@ -36,6 +36,15 @@ func WithUnknownCategoryCallback(callback OnUnknownCategory) Option {
 	}
 }
 
+// WithResetOnSuccessfulCall forces the reset of the current Category when a successful response is received.
+// Useful for probing with github_ratelimit.WithOverrideConfig for individual calls to reset an entire category.
+// Additionally useful if this rate limiter sits on top of a collection of tokens that can be rotated
+func WithResetOnSuccessfulCall() Option {
+	return func(c *Config) {
+		c.resetOnSuccess = true
+	}
+}
+
 // WithSharedState is used to set the rate limiter state from an external source.
 // Specifically, it is used to share the state between multiple rate limiters.
 // e.g.,


### PR DESCRIPTION
### Feature: `WithResetOnSuccessfulCall` Option

This PR introduces a new request option, `WithResetOnSuccessfulCall`, designed to handle discrepancies between the client-side rate limiter and the actual GitHub API state.

**Problem:**
This transport could be stacked with others, including an auth management transport like https://github.com/bored-engineer/github-rate-limit-http-transport. Continuing to wait on non-rate-limited responses would continue blocking when there could potentially be tokens available downstream.

**Solution:**
The `WithResetOnSuccessfulCall` option allows an application to send a "probe" request.
*   **Behavior:** When this option is enabled on a request, and that request successfully completes (returns a successful HTTP status code), the `github_primary_ratelimit` will **reset the tracking state** for that specific resource category.
*   **Outcome:** This effectively "unblocks" the category, allowing subsequent requests to flow normally.

**Usage:**
This is best used in conjunction with `WithLimitBypass` on a single request to periodically probe a blocked category to see if the rate limit on the server side has actually expired or if the client was mistakenly blocking.

---
*   **Fix `parseRequestCategory` logic**:
    *   Changed `github_primary_ratelimit/category.go` to use `request.URL.Path` instead of `request.URL.RawPath`.
    *   **Reason**: `RawPath` is often empty in Go's `net/url` when the path contains no characters requiring special encoding. This caused standard endpoints (like `/search`) to fail string matching and incorrectly default to the `core` limit category. `Path` is the reliable field for routing logic.
